### PR TITLE
Do not depend on cron module

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,36 +35,15 @@ class mirror_repos::config {
     content => template('mirror_repos/update-repos.sh.erb'),
   }
 
-  #If legacy cron job (/etc/cron.d) is preferred
-  if $mirror_repos::legacy_cron {
-    #run cron every night to update repos
-    cron::job { 'update-repos':
-      command => '/usr/sbin/update-repos',
-      user    => 'root',
-      require => File['/usr/sbin/update-repos'],
-      minute  => $mirror_repos::cron_minute,
-      hour    => $mirror_repos::cron_hour,
-      date    => $mirror_repos::cron_date,
-      month   => $mirror_repos::cron_month,
-      weekday => $mirror_repos::cron_weekday,
-    }
-
-    # disable crontab job
-    cron { 'update-repos':
-      ensure  => absent,
-      command => '/usr/sbin/update-repos',
-      user    => 'root',
-    }
-  } else {
-    cron { 'update-repos':
-      command => '/usr/sbin/update-repos',
-      user    => 'root',
-      hour    => $mirror_repos::cron_hour,
-      minute  => $mirror_repos::cron_minute,
-      date    => $mirror_repos::cron_date,
-      month   => $mirror_repos::cron_month,
-      weekday => $mirror_repos::cron_weekday,
-      require => File['/usr/sbin/update-repos'],
-    }
+  cron { 'update-repos':
+    command => '/usr/sbin/update-repos',
+    user    => 'root',
+    hour    => $mirror_repos::cron_hour,
+    minute  => $mirror_repos::cron_minute,
+    date    => $mirror_repos::cron_date,
+    month   => $mirror_repos::cron_month,
+    weekday => $mirror_repos::cron_weekday,
+    target  => $mirror_repos::cron_target,
+    require => File['/usr/sbin/update-repos'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,6 @@ class mirror_repos (
     Boolean $manage_vhost      = $mirror_repos::params::manage_vhost,
     Array $createrepo_options  = $mirror_repos::params::createrepo_options,
     Boolean $download_metadata = $mirror_repos::params::download_metadata,
-    Boolean $legacy_cron       = $mirror_repos::params::legacy_cron,
     String $cron_minute        = $mirror_repos::params::cron_minute,
     String $cron_hour          = $mirror_repos::params::cron_hour,
     String $cron_date          = $mirror_repos::params::cron_date,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class mirror_repos (
     String $cron_date          = $mirror_repos::params::cron_date,
     String $cron_month         = $mirror_repos::params::cron_month,
     String $cron_weekday       = $mirror_repos::params::cron_weekday,
+    String $cron_target        = $mirror_repos::params::cron_target,
     Optional[Stdlib::HTTPUrl] $proxy                            = undef,
     Optional[String] $proxy_username                            = undef,
     Optional[Variant[String,Sensitive[String]]] $proxy_password = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class mirror_repos::params {
               $cron_date          = '*'
               $cron_month         = '*'
               $cron_weekday       = '*'
+              $cron_target        = undef
     }
     default: {
               fail("${::operatingsystem} not supported")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,6 @@ class mirror_repos::params {
               $repos              = {}
               $createrepo_options = []
               $download_metadata  = false
-              $legacy_cron        = false
               $cron_minute        = '0'
               $cron_hour          = '1'
               $cron_date          = '*'

--- a/metadata.json
+++ b/metadata.json
@@ -15,10 +15,6 @@
     {
       "name": "puppetlabs-apache",
       "version_requirement": ">=1.11.0 < 9.0.0"
-    },
-    {
-      "name": "puppet-cron",
-      "version_requirement": ">=1.1.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
As mentioned in #8, the dependency on cron module could be removed entirely by using the `target` option.

When receiving an undef value, the cron module set the target to `/var/spool/cron/USER`

This way would be cleaner to get the desired configs i think:

```
class { 'mirror_repos' :
  cron_target => '/etc/cron.d/update-repos',
}
```

edit: I suggest this because sometimes dependency on upstream modules requires more management when the it is updated.  I’ve been recently forced to fork some repository only to modify the `metadata.json`.  Having less dependency reduce the required maintenance of your module.  But feel free to disregard my suggestion!