### PR TITLE
feat: add delete_old parameter to run reposync --delete

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,6 +28,10 @@ class mirror_repos::config {
     true  => '--download-metadata',
     false => '',
   }
+  $delete_old_option = $mirror_repos::delete_old ? {
+    true  => '--delete',
+    false => '',
+  }
   #copy file to update repos to localhost
   file { '/usr/sbin/update-repos':
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class mirror_repos (
     Boolean $manage_vhost      = $mirror_repos::params::manage_vhost,
     Array $createrepo_options  = $mirror_repos::params::createrepo_options,
     Boolean $download_metadata = $mirror_repos::params::download_metadata,
+    Boolean $delete_old        = $mirror_repos::params::delete_old,
     Boolean $legacy_cron       = $mirror_repos::params::legacy_cron,
     String $cron_minute        = $mirror_repos::params::cron_minute,
     String $cron_hour          = $mirror_repos::params::cron_hour,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class mirror_repos::params {
               $repos              = {}
               $createrepo_options = []
               $download_metadata  = false
+              $delete_old         = false
               $legacy_cron        = false
               $cron_minute        = '0'
               $cron_hour          = '1'

--- a/templates/update-repos.sh.erb
+++ b/templates/update-repos.sh.erb
@@ -56,10 +56,10 @@ main(){
                 $REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/
             <% end -%>
             <% if @operatingsystemmajrelease == '7' -%>
-                $REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/ <%= @download_metadata_option -%>
+                $REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/ <%= @download_metadata_option -%> <%= @delete_old_option %>
             <% end -%>
             <% if @operatingsystemmajrelease == '8' -%>
-                $REPOSYNC_CMD -q -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download-path=$REPOS_DIR/$OS/ <%= @download_metadata_option -%>
+                $REPOSYNC_CMD -q -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download-path=$REPOS_DIR/$OS/ <%= @download_metadata_option -%> <%= @delete_old_option %>
             <% end -%>
 
             #create yum repository from local synced directories


### PR DESCRIPTION
fix #17 

I’ve branched from `v0.3.0` ~~as the change affect the epp template~~, and was non-existent in master.

edit: the change affect only the `erb` template, I was assuming I had deleted every instance of `erb` previously, sorry.
but it it is still related to changes in `v.0.3.0`