### PR TITLE
Replace usage of legacy facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 #mirror_repos parameters
 class mirror_repos::params {
-  case $::osfamily {
+  case $facts['os'['family'] {
     'RedHat': {
               $packages     = ['createrepo', 'yum-utils']
               $manage_vhost = true
@@ -10,7 +10,7 @@ class mirror_repos::params {
               $repos        = {}
     }
     default: {
-              fail("${::operatingsystem} not supported")
+              fail("${facts['os']['name']} not supported")
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 #mirror_repos parameters
 class mirror_repos::params {
-  case $facts['os'['family'] {
+  case $facts['os']['family'] {
     'RedHat': {
               $packages     = ['createrepo', 'yum-utils']
               $manage_vhost = true

--- a/templates/update-repos.sh.erb
+++ b/templates/update-repos.sh.erb
@@ -52,15 +52,13 @@ main(){
             yum clean all >& /dev/null
 
             #sync remote repos to local directories
-	    <% if @operatingsystemmajrelease == '6' -%>
-            	$REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/
-	    <% end -%>
-	    <% if @operatingsystemmajrelease == '7' -%>
-            	$REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/
-	    <% end -%>
-	    <% if @operatingsystemmajrelease == '8' -%>
-                $REPOSYNC_CMD -q -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download-path=$REPOS_DIR/$OS/
-	    <% end -%>
+            <%- if @os['release']['major'] == '6' -%>
+            $REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/
+            <%- elsif @os['release']['major'] == '7' -%>
+            $REPOSYNC_CMD -q -l -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download_path=$REPOS_DIR/$OS/
+            <%- elsif @os['release']['major'] == '8' -%>
+            $REPOSYNC_CMD -q -c $CONFIG_DIR/$OS.conf --repoid=$REPO --download-path=$REPOS_DIR/$OS/
+            <%- end -%>
 
             #create yum repository from local synced directories
             $CREATEREPO_CMD --workers=8 --update $REPOS_DIR/$OS/$REPO


### PR DESCRIPTION
This module does not currently run on puppet 8 because of legacy facts:
- `$::osfamily`
- `$::operatingsystem`